### PR TITLE
FederationLink must be a string, not a url.URL

### DIFF
--- a/keycloak/users.go
+++ b/keycloak/users.go
@@ -7,10 +7,6 @@
 
 package keycloak
 
-import (
-	"net/url"
-)
-
 // UserConsentRepresentation represents client consents
 type UserConsentRepresentation struct {
 	ClientID            string    `json:"clientId,omitempty"`

--- a/keycloak/users.go
+++ b/keycloak/users.go
@@ -55,7 +55,7 @@ type UserRepresentation struct {
 	EmailVerified          *bool                             `json:"emailVerified,omitempty"`
 	Enabled                *bool                             `json:"enabled,omitempty"`
 	FederatedIdentities    []FederatedIdentityRepresentation `json:"federatedIdentities,omitempty"`
-	FederationLink         *url.URL                          `json:"federationLink,omitempty"`
+	FederationLink         string                            `json:"federationLink,omitempty"`
 	FirstName              string                            `json:"firstName,omitempty"`
 	Groups                 []string                          `json:"groups,omitempty"`
 	ID                     string                            `json:"id,omitempty"`


### PR DESCRIPTION
With `FederationLink` as a `*url.URL`, we've hit an unmarshal error.  Keycloak API documents `federationLink` as a `string`.